### PR TITLE
fix: resolved compatibility issues with compiled js

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -22,7 +22,7 @@ const api = new Router();
 // This relatively ugly code snippet looks through the v1 folder in /src/lib for all the router.ts files
 // to look at all the routes. Pretty handy as it allows to just create a folder `toto` with a router.ts to load all
 // its routes without extraneous configuration.
-glob.sync('./v1/**/router.ts', { cwd: './src/lib' }).forEach((routerPath) => {
+glob.sync('./v1/**/router.+(js|ts)', { cwd: `${__dirname}/lib` }).forEach((routerPath) => {
   // Disable @typescript-eslint/no-var-requires for code simplicity's sake
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const router = require(`./lib/${routerPath}`);


### PR DESCRIPTION
Made `glob.sync` pattern looking for both `.ts` and `.js` files : 
```typescript
'./v1/**/router.ts' => './v1/**/router.+(js|ts)'
```

and looking at the root with `__dirname` global